### PR TITLE
MZ-R37 set selection issues

### DIFF
--- a/definitions/r90.py
+++ b/definitions/r90.py
@@ -1,7 +1,7 @@
 import string
 from itertools import chain
 
-# MZ-R70/R90/R91:
+# MZ-R37/R70/R90/R91:
 change_set_moves = {'uppercase': {'uppercase': 1, 'lowercase': 2, 'numbers': 3},
                     'lowercase': {'uppercase': 3, 'lowercase': 1, 'numbers': 2},
                     'numbers':   {'uppercase': 2, 'lowercase': 3, 'numbers': 1}}

--- a/hardware.py
+++ b/hardware.py
@@ -5,7 +5,7 @@ import time
 from digipot import *
 from settings import PRESS, HOLD, wipers, recorder
 
-if recorder == 'R55 through R900':
+if recorder in ['R37', 'R55 through R900']:
     from definitions.r90 import change_set_moves, set_initial, set_uppercase, \
         set_lowercase, set_numbers, set_complete, entrypoints
 if recorder in ['R55 through R900 JPN', 'R55 through R900 JPN early FW']:
@@ -77,7 +77,10 @@ def input_string(string_ascii):
         # use the sign on the modulo result to see if we are going left or right
         push_button((lambda x: (x < 0 and 'Left' or 'Right'))(times_to_press), PRESS, abs(times_to_press))
         push_button('Stop', PRESS, 1)  # advance to next letter
-        current_set = return_current_set(letter, current_set)
+        if recorder == 'R37':
+            current_set = return_current_set(letter, wanted_set)
+        else:
+            current_set = return_current_set(letter, current_set)
     push_button('Stop', HOLD, 1)  # finish entry
 
 
@@ -107,7 +110,10 @@ def enter_labelling():
     time.sleep(0.1)
     push_button('Display', HOLD, 1)
     time.sleep(0.1)
-    push_button('Stop', PRESS, 2)
+    if recorder == 'R37':
+        push_button('Stop', PRESS, 1)
+    else:
+        push_button('Stop', PRESS, 2)
 
 
 ad5245 = hardware_setup()

--- a/mdrec.py
+++ b/mdrec.py
@@ -29,7 +29,8 @@ def parse_arguments():
     parser = argparse.ArgumentParser()
     parser.add_argument('label', default='%artist% - %title%',
                         help='Track format (e.g. %track number% - %title%)')
-    parser.add_argument('recorder', default='R55 through R900', choices=['R55 through R900',
+    parser.add_argument('recorder', default='R55 through R900', choices=['R37',
+                                                                         'R55 through R900',
                                                                          'R55 through R900 JPN',
                                                                          'R55 through R900 JPN early FW',
                                                                          'R909/R910/N1',


### PR DESCRIPTION
As far as I can tell, there is a logic bug in the `input_string()` set selection code, that was causing some track names to be garbled on my MZ-R37.

`return_current_set()` was being called with `current_set` as the basis, but the call to `enter_correct_set()` a few lines beforehand caused us to enter `wanted_set`, so, depending on the set transitions, we may enter the wrong set. The phrase "Denis & Denis" reliably triggers this issue on my MZ-R37 - the '&' character and everything following it is garbled.

This PR fixes this issue on my player, but I do not have any other devices to test it with. If my understanding of the character-entry state machine is correct, I think it should apply to the others too.

I can confirm that with this change, gmdrec works perfectly on the MZ-R37.