### PR TITLE
Direct Linux I2C access + Gtk button GUI example

### DIFF
--- a/linux-i2c/README.md
+++ b/linux-i2c/README.md
@@ -1,0 +1,7 @@
+Direct gmdrec button access via Linux i2c-dev.
+
+This requires no additional dependencies,
+and even works with `hid_mcp2221` loaded.
+
+The GUI needs `python3-gi` and `gir1.2-gtk-3.0`,
+most likely they are already installed.

--- a/linux-i2c/gmdrec.py
+++ b/linux-i2c/gmdrec.py
@@ -1,0 +1,82 @@
+import os
+import fcntl
+
+# Defined in linux/i2c-dev.h
+I2C_SLAVE = 0x0703
+
+
+class I2C(object):
+    def __init__(self, filename):
+        self.i2c = os.open(filename, os.O_RDWR)
+
+    def __del__(self):
+        self.close()
+
+    def close(self):
+        if self.i2c is not None:
+            os.close(self.i2c)
+        self.i2c = None
+
+    def write(self, addr, data):
+        res = fcntl.ioctl(self.i2c, I2C_SLAVE, addr)
+        if res != 0:
+            return ValueError(f'ioctl(I2C_SLAVE) returned {res}')
+        res = os.write(self.i2c, data)
+        if res != len(data):
+            return ValueError(f'write(<{len(data)} bytes>) returned {res}')
+
+
+class GMDRec_Rev2(I2C):
+    WIPER_LIST = [
+        "Play/Pause",
+        "Prev/Rew",
+        "Next/FFwd",
+        "Pause/Group",
+        "Stop",
+        "Vol+",
+        "TMark",
+        "PlayMode",
+        "Display",
+        "Record",
+    ]
+
+    WIPER_I2C_ADDR = 0x2C
+    EEPROM_I2C_ADDR = 0x50
+
+    def __init__(self, filename):
+        super().__init__(filename)
+        self.wiper_values = {name: self.read_eeprom(i) for i, name in enumerate(self.WIPER_LIST)}
+
+        # TODO: Derive this value from other eeprom values properly
+        self.wiper_values['Vol-'] = 212 # for me, (stop = 219, vol+ = 204)
+
+        self.shutdown_pot()
+
+    def __del__(self):
+        self.shutdown_pot()
+        super().__del__()
+
+    def shutdown_pot(self):
+        self.write(self.WIPER_I2C_ADDR, bytes([0x20, 0x00]))
+
+    def button_down(self, button):
+        self.write_to_pot(self.wiper_values[button])
+
+    def button_up(self, button):
+        self.shutdown_pot()
+
+    def write_to_pot(self, value):
+        self.write(self.WIPER_I2C_ADDR, bytes([0x00, value]))
+
+    def read_eeprom(self, index):
+        self.write(self.EEPROM_I2C_ADDR, bytes([index + 1]))
+        return os.read(self.i2c, 1)[0]
+
+
+def find_i2c_dev():
+    for filename in os.listdir('/sys/class/i2c-dev'):
+        link_dest = os.readlink(os.path.join('/sys/class/i2c-dev', filename))
+        # Example path (path should include the USB VID/PID somewhere):
+        # '../../devices/pci0000:00/.../0003:04D8:00DD.000E/i2c-8/i2c-dev/i2c-8'
+        if ':04d8:00dd' in link_dest.lower():
+            return f'/dev/{filename}'

--- a/linux-i2c/gui.py
+++ b/linux-i2c/gui.py
@@ -1,0 +1,31 @@
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk
+
+from gmdrec import GMDRec_Rev2, find_i2c_dev
+
+i2c_dev = find_i2c_dev()
+assert i2c_dev is not None
+
+gmdrec = GMDRec_Rev2(i2c_dev)
+
+def on_button_pressed(button):
+    gmdrec.button_down(button.props.label)
+
+def on_button_released(button):
+    gmdrec.button_up(button.props.label)
+
+window = Gtk.Window(title='GMDRec Linux I2C Remote Button Tester')
+window.set_default_size(200, -1)
+vbox = Gtk.VBox()
+vbox.props.spacing = 6
+vbox.props.border_width = 12
+for label in sorted(gmdrec.wiper_values.keys()):
+    button = Gtk.Button(label=label)
+    button.connect('pressed', on_button_pressed)
+    button.connect('released', on_button_released)
+    vbox.add(button)
+window.add(vbox)
+window.show_all()
+window.connect('destroy', Gtk.main_quit)
+Gtk.main()


### PR DESCRIPTION
Example code for how to access the I2C devices directly on Linux without having to go through the Adafruit libraries and without having to unload `hid_mcp2221`. Comes with a small Gtk GUI that just allows pressing of buttons on the remote (as long as the button is pressed in the Gtk UI, the resistor value will be valid, so one can e.g. fast forward or long-press by long-pressing the corresponding button on the UI).

Only implemented for Rev2 of the board, and tested with MZ-N510 only for now (text labels adjusted based on that). The "Vol-" value should be calculated from the other calibration values, right now it's hardcoded and works for my particular board (based on the EEPROM values there). Not sure if linear interpolation between "Stop" and "Vol+" is accurate enough, it did work for me.